### PR TITLE
fix: no longer assume that bash must exist

### DIFF
--- a/QSynthesis/Frontend/Dialogs/Extern/TerminalDialog.cpp
+++ b/QSynthesis/Frontend/Dialogs/Extern/TerminalDialog.cpp
@@ -96,7 +96,7 @@ bool TerminalDialog::runInCmd() {
             &TerminalDialog::onProcessFinished);
 
     m_pTerminal->setWorkingDirectory(workingDir);
-    m_pTerminal->start("/bin/bash", {tempPath});
+    m_pTerminal->start("/bin/sh", {tempPath});
 #elif defined(Q_OS_MAC)
     qDebug() << workingDir;
     m_pTerminal = new QProcess(this);

--- a/QSynthesis/Frontend/Tabs/Tuning/TuningTab_Render.cpp
+++ b/QSynthesis/Frontend/Tabs/Tuning/TuningTab_Render.cpp
@@ -165,7 +165,7 @@ bool TuningTab::renderSelection() {
     QTextStream fs(&tempFile);
 
     // Initial part of temp.sh
-    fs << "#!/bin/bash" << Qt::endl;
+    fs << "#!/bin/sh" << Qt::endl;
     fs << Qt::endl;
 
     fs << "export loadmodule=" << Qt::endl;
@@ -274,7 +274,7 @@ bool TuningTab::renderSelection() {
 
     fs.setDevice(&helperFile);
 
-    fs << "#!/bin/bash" << Qt::endl;
+    fs << "#!/bin/sh" << Qt::endl;
     fs << Qt::endl;
 
     fs << "if [ ! -f \"${temp}\" ]; then" << Qt::endl;

--- a/QSynthesis/Global/QS/SystemApis.cpp
+++ b/QSynthesis/Global/QS/SystemApis.cpp
@@ -152,7 +152,7 @@ void RevealFile(const QString &filename) {
         if (!filename.endsWith(Slash)) {
             filename.append(Slash);
         }
-        QProcess::startDetached("bash", {"-c", "open \'" + filename + "\'"});
+        QProcess::startDetached("sh", {"-c", "open \'" + filename + "\'"});
     } else if (info.isFile()) {
         QStringList scriptArgs;
         scriptArgs << QLatin1String("-e")
@@ -166,10 +166,10 @@ void RevealFile(const QString &filename) {
     }
 #else
     if (info.isDir()) {
-        QProcess::startDetached("bash", {"-c", "xdg-open \'" + filename + "\'"});
+        QProcess::startDetached("sh", {"-c", "xdg-open \'" + filename + "\'"});
     } else if (info.isFile()) {
         QString arg = PathFindUpper(filename);
-        QProcess::startDetached("bash", {"-c", "xdg-open \'" + arg + "\'"});
+        QProcess::startDetached("sh", {"-c", "xdg-open \'" + arg + "\'"});
     }
 #endif
 }

--- a/QSynthesis/Global/UTAU/Render/QBatchRenderer_Unix.cpp
+++ b/QSynthesis/Global/UTAU/Render/QBatchRenderer_Unix.cpp
@@ -16,7 +16,7 @@ bool QBatchRenderer::generateUnixBatch(const QList<RenderArgs> &args) const {
         (args.isEmpty() ? Utau::DEFAULT_VALUE_TEMPO : args.front().resamplerArgs.tempo());
 
     // Initial part of temp.sh
-    fs << "#!/bin/bash" << Qt::endl;
+    fs << "#!/bin/sh" << Qt::endl;
     fs << Qt::endl;
 
     fs << "export loadmodule=" << Qt::endl;
@@ -122,7 +122,7 @@ bool QBatchRenderer::generateUnixHelper() const {
 
     QTextStream fs(&helperFile);
 
-    fs << "#!/bin/bash" << Qt::endl;
+    fs << "#!/bin/sh" << Qt::endl;
     fs << Qt::endl;
 
     fs << "if [ ! -f \"${temp}\" ]; then" << Qt::endl;


### PR DESCRIPTION
bash 不会默认预装在部分 Linux 发行版
MacOS X 的 bash 因许可证问题停留在旧版本，未来可能会被移除